### PR TITLE
Updated playground to include examples of captions and chapters

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,9 +4,8 @@
     <title>Iono Playground</title>
     <link rel="stylesheet"
           href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.7.5/css/bulma.min.css">
-    <script defer src="https://p2.iono.qa/bundle/player.js"></script>
-    <script
-            src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
+    <script defer src="https://p2.iono.fm/bundle/0.0.51/player.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
     <script src="https://vuejs.org/js/vue.js"></script>
 </head>
 
@@ -27,7 +26,15 @@
                 <div id="audiowrap">
                     <progress @click='progressBarClicked()' id='progress-bar'
                               class="progress is-primary" value="0" max="1"></progress>
-                    <span>{{position}} / {{ duration | formatDuration }}</span>
+                    <span>{{ position | formatDuration }} / {{ duration | formatDuration }}</span>
+                    
+                    <div id="chapters">
+                        <h4>Chapters</h4>
+                        <ul id="chaptersList">
+                            <li :class="{active: chapterText === chapter.text}" v-for="chapter in chapters">{{chapter.text}}</li>
+                        </ul>
+                    </div>
+
                     <div id="tracks">
                         <a @click="previousPlaylistItem()" id="btnPrev">&larr;</a><a
                            @click="nextPlaylistItem()" id="btnNext">&rarr;</a>

--- a/styles/style.scss
+++ b/styles/style.scss
@@ -39,6 +39,7 @@ p { color:#fff; display:block; font-size:.9rem; font-weight:400; margin:0 0 2px;
 a,a:visited { color:#8cc3e6; outline:0; text-decoration:underline; }
 a:hover,a:focus { color:#bbdef5; }
 p a,p a:visited { line-height:inherit; }
+h4 { font-weight: 600; }
 
 
 /* Misc.
@@ -168,6 +169,18 @@ color:#fff;
 #tracks a::-moz-focus-inner {
 border:0;
 padding:0;
+}
+
+#chapters {
+    margin: 1.5rem 0;
+}
+
+#chapters .active {
+    font-weight: 600;
+}
+#chaptersList {
+    list-style: decimal;
+    padding-left: 2em;
 }
 
 /* Media Queries


### PR DESCRIPTION
I've had a look at some of the issues you've logged and tried to get a few of them fixed as part of this pull request.

The following issues should be resolved with this pull request:

https://github.com/sharpstream/iono-playground/issues/3, https://github.com/sharpstream/iono-playground/issues/4,  and https://github.com/sharpstream/iono-playground/issues/10

From what I could tell, at least for the first two playlist items, there wasn't a **chapters** text track as part of the playlist item. To get chapters you must supply a text track with it's `kind` attribute set to `chapters` as per the documentation, eg.

```js
{
  // ... other playlist item fields
  text: [
    {
      kind: 'chapters',
      language: 'en',
      url: 'https://example.com/chapters.vtt'
    }
  ]
}
```

https://github.com/sharpstream/iono-playground/issues/13

The duration was firing twice because we trigger it once on playlist item load when the playlist item has a `metadata.duration`, but this is not guaranteed to match the actual media duration, which you get once the media element has loaded enough audio data to determine a duration. When the media element gets a duration it fires its `durationchange` event, which we then check against the metadata duration. If the durations differ, we update the duration to the one reported by the media element and trigger another `durationchange` event.
A lot of the time these durations are out by a couple milliseconds, so I've pushed a change that only triggers the second `durationchange` event if the durations differ by more than a threshold.

https://github.com/sharpstream/iono-playground/issues/14

This should no longer happen. Had to do with how I clear some player flags when changing playlist items.

https://github.com/sharpstream/iono-playground/issues/15

I've enabled the preload feature on the player now, it should work as documented.

Thanks for the feedback, it really helps to have an extra pair of eyes on things! I'll keep my eye on this repo in case you come across any more issues.